### PR TITLE
Page viewing permissions

### DIFF
--- a/plandarm/accounts/decorators.py
+++ b/plandarm/accounts/decorators.py
@@ -1,0 +1,17 @@
+from django.http import HttpResponse
+from django.shortcuts import redirect
+from accounts.models import Profile
+
+
+def logged_out(view_func):
+    def wrapper_func(request, *args, **kwargs):
+        if request.user.is_authenticated:
+            profile = Profile.objects.get(user=request.user)
+            page_id = str(profile.page_set.first().id)
+            
+            return redirect('/page/'+page_id)
+        else:
+            return view_func(request, *args, **kwargs)
+
+    return wrapper_func
+    

--- a/plandarm/accounts/urls.py
+++ b/plandarm/accounts/urls.py
@@ -3,10 +3,9 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.mainPage, name='main'),
+    path('', views.rootRedirect, name='root'),
     
     path('login/', views.loginPage, name='login'),
     path('logout/', views.logoutUser, name='logout'),
-
     path('register/', views.registerPage, name='register'),
 ]

--- a/plandarm/accounts/views.py
+++ b/plandarm/accounts/views.py
@@ -4,13 +4,14 @@ from django.http import HttpResponse
 from django.contrib.auth import authenticate, login, logout
 from django.contrib import messages
 
+from .models import Profile
 from .forms import RegistrationForm
+from .decorators import logged_out
 
-# Create your views here.
+def rootRedirect(request):
+    return redirect('login')
 
-def mainPage(request):
-    return render(request, 'accounts/index.html')
-
+@logged_out
 def loginPage(request):
     if request.method == 'POST':
         username = request.POST.get('username')
@@ -19,8 +20,11 @@ def loginPage(request):
         user = authenticate(request, username=username, password=password)
 
         if user is not None:
+            profile = Profile.objects.get(user=user)
+            page_id = profile.page_set.first().id
             login(request, user)
-            return redirect('/admin')
+
+            return redirect('/page/' + str(page_id))
         else:
             messages.info(request, 'Incorrect login data')
 
@@ -30,6 +34,7 @@ def logoutUser(request):
     logout(request)
     return redirect('login')
 
+@logged_out
 def registerPage(request):
     form = RegistrationForm()
 

--- a/plandarm/pages/templates/pages/editor.html
+++ b/plandarm/pages/templates/pages/editor.html
@@ -33,7 +33,7 @@
 
         <ul class="sidebar-tree">
           <li><div class="caret"></div>
-            <a href="#">Log out</a> <!-- %{ url 'logout' %} -->
+            <a href="{% url 'logout' %}">Log out</a>
             <ul class="nested">
               <li><a href="#">Docs</a></li>
               <li><a href="#">Contributors</a></li>

--- a/plandarm/pages/views.py
+++ b/plandarm/pages/views.py
@@ -1,10 +1,15 @@
 from django.shortcuts import render
 from pages.models import Page 
+from django.http import HttpResponse
 
-# Create your views here.
+from django.contrib.auth.decorators import login_required
 
+@login_required(login_url='login')
 def page(request, page_id):
     page = Page.objects.get(id=page_id)
     context = {'page': page}
-    
+ 
+    if page.owner.user.id != request.user.id:
+        return HttpResponse('You are not authorized to view this page')
+
     return render(request, 'pages/editor.html', context)


### PR DESCRIPTION
Changed: pages can be viewed only by their respective owners
Changed: redirections
  - site root redirects to login, if not logged in
  - site root redirects to the first page of the user, if logged in

  - login page redirects to the first page of the user, on successful log in
  - login page redirects to the first page of the user, if logged in

  - registration page redirects to login page on successful registration
  - registration page redirects to first page of the user, if logged in